### PR TITLE
Remove BOMs and fix viewport meta

### DIFF
--- a/11/flex-1.html
+++ b/11/flex-1.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/flex-10.html
+++ b/11/flex-10.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>플렉스 박스 레이아웃</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1 1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     .container {
       width:800px;

--- a/11/flex-11.html
+++ b/11/flex-11.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>플렉스 박스 레이아웃</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1 1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     .container {
       width:800px;

--- a/11/flex-2.html
+++ b/11/flex-2.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/flex-3.html
+++ b/11/flex-3.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/flex-4.html
+++ b/11/flex-4.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/flex-5.html
+++ b/11/flex-5.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/flex-6.html
+++ b/11/flex-6.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/flex-7.html
+++ b/11/flex-7.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/flex-8.html
+++ b/11/flex-8.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>플렉스 박스 레이아웃</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1 1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     /* Do it! 플렉스 항목 간의 간격을 10px로 적용하기 */
     .container {

--- a/11/flex-9.html
+++ b/11/flex-9.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/margin-1.html
+++ b/11/margin-1.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/margin-2.html
+++ b/11/margin-2.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/margin-3.html
+++ b/11/margin-3.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/flex-1.html
+++ b/11/results/flex-1.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/flex-10.html
+++ b/11/results/flex-10.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>플렉스 박스 레이아웃</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1 1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     .container {
       width:800px;

--- a/11/results/flex-11.html
+++ b/11/results/flex-11.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>플렉스 박스 레이아웃</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1 1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     .container {
       width:800px;

--- a/11/results/flex-2.html
+++ b/11/results/flex-2.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/flex-3.html
+++ b/11/results/flex-3.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/flex-4.html
+++ b/11/results/flex-4.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/flex-5.html
+++ b/11/results/flex-5.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/flex-6.html
+++ b/11/results/flex-6.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/flex-7.html
+++ b/11/results/flex-7.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/flex-8-2.html
+++ b/11/results/flex-8-2.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>플렉스 박스 레이아웃</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1 1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     /* Do it! 플렉스 항목 간의 간격을 10px로 적용하기 */
     .container {

--- a/11/results/flex-8-3.html
+++ b/11/results/flex-8-3.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>플렉스 박스 레이아웃</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1 1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     .container {
       width:400px;

--- a/11/results/flex-8.html
+++ b/11/results/flex-8.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>플렉스 박스 레이아웃</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1 1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     /* Do it! 플렉스 항목 간의 간격을 10px로 적용하기 */
     .container {

--- a/11/results/flex-9.html
+++ b/11/results/flex-9.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/margin-1.html
+++ b/11/results/margin-1.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/margin-2.html
+++ b/11/results/margin-2.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">

--- a/11/results/margin-3.html
+++ b/11/results/margin-3.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM bytes from html files under `11/` and `11/results/`
- fix malformed viewport meta tag (`initial-scale=1 1` -> `initial-scale=1`)

## Testing
- `grep -r "initial-scale=1 1" 11`
- `find 11 11/results -type f \( -name '*.html' -o -name '*.css' \) -print0 | xargs -0 grep -lI $'\xEF\xBB\xBF' | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_684067c414e4832d8ae0b7fa058e25ef