### PR TITLE
Fix comment typo in button-2 example

### DIFF
--- a/19/results/button-2.html
+++ b/19/results/button-2.html
@@ -50,7 +50,7 @@
       const proceedButton = document.querySelector('#proceed');
 
       checkbox.addEventListener('change', function() {
-        proceedButton.classList.toggle('enabled', this.checked);  // 체크했다면 .enabeld 토글
+        proceedButton.classList.toggle('enabled', this.checked);  // 체크했다면 .enabled 토글
         proceedButton.classList.toggle('disabled', !this.checked);  // 체크하지 않았다면 .disabled 토글
         proceedButton.disabled = !this.checked;  // 버튼의 활성화/비활성화 상태
       });


### PR DESCRIPTION
## Summary
- fix a typo in `19/results/button-2.html` comment

## Testing
- `grep -R "enabeld" -n .. | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_684068bbb38c832d8f0d17acb7b06d9b