### PR TITLE
Add CSS summary for chapters 08-14

### DIFF
--- a/08-14.css_essential_summary.md
+++ b/08-14.css_essential_summary.md
@@ -1,0 +1,42 @@
+# CSS 핵심 요약 (Ch08~14)
+
+이 문서는 저장소의 08번부터 14번 폴더까지 학습할 때 꼭 기억해야 할 CSS 개념을 정리한 것입니다.
+
+## 08: 박스 모델과 배치
+- `margin`, `border`, `padding`, `content` 영역의 이해
+- `box-sizing` 으로 실제 너비 계산 방법 제어
+- `display` 속성(`block`, `inline`, `inline-block` 등)과 `float`
+- `position` 속성(`static`, `relative`, `absolute`, `fixed`)
+- 그림자와 테두리(`box-shadow`, `border`)
+
+## 09: 배경과 그라디언트
+- `background-image`, `background-size`, `background-position`
+- 여러 장의 배경과 `background-clip`
+- `linear-gradient`와 `radial-gradient` 활용
+
+## 10: 반응형 레이아웃과 단위
+- 상대 단위 `em`/`rem` 사용법
+- 이미지 비율 유지: `object-fit`
+- 뷰포트 크기에 따라 스타일을 바꾸는 `@media` 쿼리
+
+## 11: Flexbox 레이아웃
+- 플렉스 컨테이너와 아이템(`display: flex`)
+- 방향 설정(`flex-direction`), 정렬(`justify-content`, `align-items`)
+- 여러 줄 배치(`flex-wrap`), `flex` 단축 속성
+
+## 12: CSS Grid
+- 격자 기반 배치(`display: grid`)
+- 행과 열 정의(`grid-template-columns`, `grid-template-rows`)
+- 영역 병합과 반응형 그리드(`grid-column`, `grid-row`, 미디어 쿼리)
+
+## 13: 고급 선택자와 의사 클래스
+- 속성 선택자(`[type="text"]` 등)와 구조 선택자(`:nth-child` 등)
+- 의사 요소(`::before`, `::after`) 활용
+- 계산 함수 `calc()`, `clamp()`, `minmax()`
+
+## 14: 변환과 애니메이션
+- 2D/3D 변환(`transform: translate/rotate/scale/skew`)
+- `transition` 으로 부드러운 상태 변화
+- `@keyframes`를 사용한 애니메이션 정의
+
+각 장의 예제 파일을 직접 수정해 보며 위 개념들을 익히면 3일 만에 핵심을 정리할 수 있습니다.

--- a/08-14.css_essential_summary.mermaid
+++ b/08-14.css_essential_summary.mermaid
@@ -1,0 +1,17 @@
+flowchart LR
+    subgraph "CSS Essentials"
+        C08["08 Box Model"] --> C09["09 Backgrounds"]
+        C09 --> C10["10 Responsive"]
+        C10 --> C11["11 Flexbox"]
+        C11 --> C12["12 Grid"]
+        C12 --> C13["13 Selectors"]
+        C13 --> C14["14 Animation"]
+    end
+    C08 --> MARGIN[margin/border/padding]
+    C08 --> POSITION[position & float]
+    C09 --> BG[images & gradients]
+    C10 --> MEDIA[em/rem & media queries]
+    C11 --> FLEX[flex container/items]
+    C12 --> GRID[template areas]
+    C13 --> ADVSELECT[attr & pseudo classes]
+    C14 --> TRANSFORM[transform & keyframes]


### PR DESCRIPTION
## Summary
- document core CSS topics for directories 08 through 14
- provide a quick reference mermaid diagram for chapter relationships

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684590dda8dc832d96807e6081d272d5